### PR TITLE
Add missing options parameter to getBoardGameExpansion method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -134,7 +134,7 @@ function createClient(rootUrl) {
       .then(mapper.mapBoardGameResponse)
   }
 
-  client.getBoardGameExpansion = function getBoardGameExpansion(name) {
+  client.getBoardGameExpansion = function getBoardGameExpansion(name, options) {
     var exact = options && options.exact
 
     return findThing(name, {


### PR DESCRIPTION
the `getBoardGameExpansion` method will always throw an error currently since it attempts to use the undeclared `options` parameter within the function